### PR TITLE
Save and require isotonic calibrator

### DIFF
--- a/predict_today.py
+++ b/predict_today.py
@@ -1,3 +1,4 @@
+import os
 import pandas as pd
 import statsapi
 from pybaseball import playerid_lookup
@@ -9,8 +10,14 @@ import pickle
 
 # Load tuned booster and calibrator
 model = xgb.Booster()
-model.load_model('xgboost_yrfi_leakfree_tuned.json')
-calibrator = pickle.load(open('isotonic_calibrator.pkl', 'rb'))
+model.load_model("xgboost_yrfi_leakfree_tuned.json")
+CALIBRATOR_FILE = "isotonic_calibrator.pkl"
+if not os.path.exists(CALIBRATOR_FILE):
+    raise FileNotFoundError(
+        f"Calibrator file '{CALIBRATOR_FILE}' not found. Run train_model.py first."
+    )
+with open(CALIBRATOR_FILE, "rb") as f:
+    calibrator = pickle.load(f)
 expected_features = model.feature_names
 
 @lru_cache(maxsize=None)

--- a/train_model.py
+++ b/train_model.py
@@ -1,4 +1,5 @@
 import os
+import pickle
 import pandas as pd
 from sklearn.model_selection import TimeSeriesSplit, GridSearchCV
 from sklearn.metrics import accuracy_score, roc_auc_score, f1_score, log_loss
@@ -157,8 +158,11 @@ def main():
     print("LogLoss:", round(log_loss(y_test, proba),4))
 
     best_model.get_booster().save_model(MODEL_FILE)
-    pd.to_pickle(ir, CALIBRATOR_FILE)
-    print(f"Saved tuned model to {MODEL_FILE} and calibrator to {CALIBRATOR_FILE}")
+    with open(CALIBRATOR_FILE, "wb") as f:
+        pickle.dump(ir, f)
+    print(
+        f"Saved tuned model to {MODEL_FILE} and calibrator to {CALIBRATOR_FILE}"
+    )
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
## Summary
- persist the fitted isotonic regression model during training
- gracefully handle missing calibrator when predicting

## Testing
- `python -m py_compile train_model.py predict_today.py`

------
https://chatgpt.com/codex/tasks/task_e_68424201bad48322b9af02494b4d85cb